### PR TITLE
Updated version manifest for mumu

### DIFF
--- a/applications/mumu.json
+++ b/applications/mumu.json
@@ -5,6 +5,7 @@
   "keywords": ["service", "rest", "api", "content"],
 
   "versions": {
+    "0.0.2": {"type": "github", "location": "anddimario/mumu", "tag": "v0.0.2", "engines": {"arangodb": "^3.0.0"}},
     "0.0.1": {"type": "github", "location": "anddimario/mumu", "tag": "v0.0.1", "engines": {"arangodb": "^3.0.0"}}
   }
 }


### PR DESCRIPTION
Necessary because the installable version from foxx isn't last version