### PR TITLE
Add Prometheus exporter

### DIFF
--- a/applications/prometheus-exporter.json
+++ b/applications/prometheus-exporter.json
@@ -1,0 +1,10 @@
+{
+  "author": "Manuel Pöter",
+  "description": "A simple Foxx service for ArangoDB that provides the internal statistics from ArangoDB in the Prometheus format.",
+  "license": "MIT",
+  "keywords": ["prometheus", "monitoring"],
+
+  "versions": {
+    "0.1.0": { "type": "github", "location": "Lean5/arango-prometheus-exporter", "tag": "v0.1.0", "engines": {"arangodb": "^3.0.0"}}
+  }
+}


### PR DESCRIPTION
This is a simple Foxx service that provides the internal statistics from ArangoDB in the Prometheus format.