### PR TITLE
Added services RecallGraph and foxx-tracer-collector

### DIFF
--- a/applications/RecallGraph.json
+++ b/applications/RecallGraph.json
@@ -1,0 +1,10 @@
+{
+  "author": "Aditya Mukhopadhyay",
+  "description": "A versioning data store for time-variant graph data.",
+  "license": "Apache-2.0",
+  "keywords": ["temporal-graphs", "data-versioning"],
+
+  "versions": {
+    "1.0.0": { "type": "github", "location": "RecallGraph/RecallGraph", "tag": "v1.0.0", "engines": {"arangodb": ">=3.5.0"}}
+  }
+}

--- a/applications/foxx-tracer-collector.json
+++ b/applications/foxx-tracer-collector.json
@@ -1,0 +1,10 @@
+{
+  "author": "Aditya Mukhopadhyay",
+  "description": "A collector agent for OpenTracing spans emitted by foxx-tracer.",
+  "license": "MIT",
+  "keywords": ["opentracing"],
+
+  "versions": {
+    "0.0.8": { "type": "github", "location": "RecallGraph/foxx-tracer-collector", "tag": "v0.0.8", "engines": {"arangodb": ">=3.5.0"}}
+  }
+}


### PR DESCRIPTION
**RecallGraph** is a versioned-graph data store - it retains all changes that its data (vertices and edges) have gone through to reach their current state. It supports point-in-time graph traversals, letting the user query any past state of the graph just as easily as the present.

**foxx-tracer-collector** acts as a collector agent for OpenTracing spans emitted by [foxx-tracer](https://github.com/RecallGraph/foxx-tracer).